### PR TITLE
Fix footnote block, quote block, enhance inline code box

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - dev**
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   compile:

--- a/Supplemental/sample-chinese.md
+++ b/Supplemental/sample-chinese.md
@@ -102,5 +102,5 @@ $$
 
 [TOC]
 
-[^1]: 从 https://en.wikipedia.org/wiki/Lorem_ipsum *Forke*得到
+[^1]: 从 https://en.wikipedia.org/wiki/Lorem_ipsum 整理得到
 

--- a/src/latex-theme.scss
+++ b/src/latex-theme.scss
@@ -589,6 +589,21 @@ h6.md-focus.md-heading:before {
   @extend %h6-with-count;
 }
 
+// 参考文献块
+.footnotes-area {
+  /* 把参考资料块的文字大小和文字颜色与正文统一 */
+  .footnote-line {
+    color: var(--text-color);
+    font-size: var(--base-font-size);
+  }
+
+  /* 默认情况下，Typora 会给参考文献块顶部加一条横线，这里把它隐藏掉 */
+  hr {
+    border: 0;
+    color: #00000000;
+  }
+}
+
 /* 目录 */
 .md-toc-content {
   margin-left: 2em;

--- a/src/latex-theme.scss
+++ b/src/latex-theme.scss
@@ -614,14 +614,14 @@ h6.md-focus.md-heading:before {
 .md-toc-inner {
   margin-left: 0 !important;
   @if $theme == "light" {
-    color: black !important;
+    color: var(--text-color) !important;  // var(--text-color) 被 Typora 定义
   } @else if $theme == "dark" {
     color: #dddddd !important;
   }
 }
 .md-toc-item {
   @if $theme == "light" {
-    color: black !important;
+    color: var(--text-color) !important;
   } @else if $theme == "dark" {
     color: #dddddd !important;
   }

--- a/src/latex-theme.scss
+++ b/src/latex-theme.scss
@@ -406,18 +406,11 @@ blockquote {
   font-family: var(--quote-font), var(--base-Latin-font),
     var(--base-Chinese-font), -apple-system, serif;
   font-size: var(--quote-font-size);
-  border-left: 3px solid grey;
   /* 文字离左边框的距离 */
   padding-left: 16px;
   padding-right: 20pt;
   /* 左边框离页面边的距离 */
   margin-left: 20px;
-  @if $theme == "light" {
-    color: grey;
-  } @else if $theme == "dark" {
-    /* 文字颜色 */
-    color: #bfbfbf;
-  }
 }
 
 hr {
@@ -591,13 +584,13 @@ h6.md-focus.md-heading:before {
 
 // 参考文献块
 .footnotes-area {
-  /* 把参考资料块的文字大小和文字颜色与正文统一 */
   .footnote-line {
+    // 把参考资料块的文字大小和文字颜色与正文统一
     color: var(--text-color);
     font-size: var(--base-font-size);
   }
 
-  /* 默认情况下，Typora 会给参考文献块顶部加一条横线，这里把它隐藏掉 */
+  // 默认情况下，Typora 会给参考文献块顶部加一条横线，这里把它隐藏掉
   hr {
     border: 0;
     color: #00000000;
@@ -614,7 +607,7 @@ h6.md-focus.md-heading:before {
 .md-toc-inner {
   margin-left: 0 !important;
   @if $theme == "light" {
-    color: var(--text-color) !important;  // var(--text-color) 被 Typora 定义
+    color: var(--text-color) !important;
   } @else if $theme == "dark" {
     color: #dddddd !important;
   }

--- a/src/latex-theme.scss
+++ b/src/latex-theme.scss
@@ -505,6 +505,10 @@ li {
 /* ============ 多级列表样式END ============ */
 
 /* 行内代码 */
+code {
+  font-family: var(--code-font), var(--ui-font), monospace; 
+}
+h1 code, h2 code, h3 code, h4 code, h5 code, h6 code,
 p code,
 li code {
   @if $theme == "light" {


### PR DESCRIPTION
在这次改动后：  
- 脚注块的字体大小与字体颜色与正文相同
- 引用块除缩进外与正文块无任何差异
- 内嵌代码块的字体与代码块统一，且在标题中的内嵌代码块会带上边框
- 文档和注释中的一些细节被修复