### PR TITLE
Override mermaidChart font size

### DIFF
--- a/src/scss/typora.scss
+++ b/src/scss/typora.scss
@@ -90,6 +90,11 @@ pre.md-meta-block {
   font-family: var(--code-font), var(--ui-font), monospace;
 }
 
+/* 覆盖mermaid的默认字体大小（由于mermaid图像本身大小无法改变，如果设置typora字体过大或过小可能产生问题） */
+[id *="mermaidChart"] {
+  font-size: 1em !important;
+}
+
 // override the default style for focused headings
 #write > h3.md-focus:before,
 #write > h4.md-focus:before,


### PR DESCRIPTION
原本是 pr #108 的功能，现在拆出来了。原因是这个配置导致 Linux 上的 mermaid 图像显示不符合预期。  
需要进一步寻找解决这个问题的方案。

![image](https://user-images.githubusercontent.com/19510622/219082593-47ac4942-a6cd-4d44-9642-0f5cb267f0ea.png)
