### PR TITLE
fix: fix display format when unordered lists nested in ordered lists

### DIFF
--- a/src/scss/list.scss
+++ b/src/scss/list.scss
@@ -18,11 +18,11 @@
   ol {
     counter-reset: liist;
     list-style: none;
-    li {
+    > li {
       counter-increment: liist;
       position: relative;
     }
-    li::before {
+    > li::before {
       content: "(" counter(liist, lower-alpha) ")";
       position: absolute;
       left: -1.8em;
@@ -32,11 +32,11 @@
       counter-reset: liiist;
       list-style: none;
       margin: 0;
-      li {
+      > li {
         counter-increment: liiist;
         position: relative;
       }
-      li::before {
+      > li::before {
         content: counter(liiist, lower-roman) ".";
         align-self: flex-end;
         position: absolute;


### PR DESCRIPTION
fix #123.

**before:** 
<img width="607" alt="image" src="https://github.com/Keldos-Li/typora-latex-theme/assets/23137268/7648e30d-ce17-4db9-9b73-e5891ecba442">

**after:**
<img width="607" alt="image" src="https://github.com/Keldos-Li/typora-latex-theme/assets/23137268/854c175e-ce82-4d94-a3d8-520f52f29d4c">