### PR TITLE
chore: update dependencies in dev-build.yml to v4

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
           sudo apt install ruby sass -y
@@ -20,7 +20,7 @@ jobs:
         run: |
           cd ./src; make
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: my-artifact
           path: |


### PR DESCRIPTION
Update dependencies in `dev-build.yml` to v4.  
This only affects build target in dev branches and **does not affect release artifacts**.  
If everything in this pr works properly, then modify `release.yml`.  