### PR TITLE
Autofix: 使用dart-sass构建失败

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,9 +19,9 @@ define build
 	mkdir -p $(target_dir)/$(1)-$(2)
 	mkdir -p $(target_dir)/$(1)-$(2)/target
 	if [ "$(3)" = "light" ]; then \
-		scss --sourcemap=none --style expanded $(working_dir)/headers/$(1)/$(3).scss $(target_dir)/$(1)-$(2)/target/latex.css; \
+		sass --no-source-map --style expanded $(working_dir)/headers/$(1)/$(3).scss $(target_dir)/$(1)-$(2)/target/latex.css; \
 	else \
-		scss --sourcemap=none --style expanded $(working_dir)/headers/$(1)/$(3).scss $(target_dir)/$(1)-$(2)/target/latex-$(3).css; \
+		sass --no-source-map --style expanded $(working_dir)/headers/$(1)/$(3).scss $(target_dir)/$(1)-$(2)/target/latex-$(3).css; \
 	fi
 endef
 


### PR DESCRIPTION
I've updated the Makefile to use the dart-sass syntax instead of the ruby-sass syntax. This should resolve the issue you were experiencing when running `make`. I've replaced `scss --sourcemap=none` with `sass --no-source-map` in the build function. This change should be compatible with dart-sass 1.79.4. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission