### PR TITLE
fix: update deprecated workflow dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
+
 on:
-  create:
+  push:
     tags:
       - v*
 
@@ -12,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Dart Sass
         uses: robinraju/release-downloader@v1
         with:
@@ -27,9 +28,7 @@ jobs:
         run: |
           cd ./src; make all-and-compress
       - name: Release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: false
-          files: |
-            ./src/latex-theme/*.zip
+          files: ./src/latex-theme/*.zip


### PR DESCRIPTION
- update: `actions/checkout@v2` -> `actions/checkout@v2`
- remove deprecated `marvinpinto/action-automatic-releases@latest`, change to `softprops/action-gh-release@v2`

tested in my private repo.