### PR TITLE
feat : Add CSS variable toggle for blockquote borders

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,18 +11,8 @@ pandoc = pandoc
 $(shell mkdir -p $(working_dir))
 $(shell mkdir -p $(target_dir))
 
-# $(shell cp -r $(base_dir)/scss $(working_dir)/scss)
-# $(shell cp -r $(base_dir)/headers $(working_dir)/headers)
-
-# This solves the issue where changes in the source files don't take effect, 
-# because the $(shell) command is only executed once during Makefile parsing
-define update-build
-	rm -rf $(working_dir)
-	mkdir -p $(working_dir)/scss
-	mkdir -p $(working_dir)/headers
-	cp -r $(base_dir)/scss/* $(working_dir)/scss/
-	cp -r $(base_dir)/headers/* $(working_dir)/headers/
-endef
+$(shell cp -r $(base_dir)/scss $(working_dir)/scss)
+$(shell cp -r $(base_dir)/headers $(working_dir)/headers)
 
 # $(1) is the name of operating system, $(2) is typora or pandoc, $(3) is light or dark theme
 define build
@@ -37,7 +27,6 @@ endef
 
 # $(1) is the name of operating system
 define build-typora
-	$(call update-build)
 	$(call build,$(1),$(typora),light)
 	$(call build,$(1),$(typora),dark)
 	if [ "$(1)" = "$(windows)" ]; then \
@@ -52,7 +41,6 @@ define build-typora
 endef
 
 define build-pandoc
-	$(call update-build)
 	$(call build,$(linux),$(pandoc),light)
 	$(call build,$(linux),$(pandoc),dark)
 endef

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,8 +11,18 @@ pandoc = pandoc
 $(shell mkdir -p $(working_dir))
 $(shell mkdir -p $(target_dir))
 
-$(shell cp -r $(base_dir)/scss $(working_dir)/scss)
-$(shell cp -r $(base_dir)/headers $(working_dir)/headers)
+# $(shell cp -r $(base_dir)/scss $(working_dir)/scss)
+# $(shell cp -r $(base_dir)/headers $(working_dir)/headers)
+
+# This solves the issue where changes in the source files don't take effect, 
+# because the $(shell) command is only executed once during Makefile parsing
+define update-build
+	rm -rf $(working_dir)
+	mkdir -p $(working_dir)/scss
+	mkdir -p $(working_dir)/headers
+	cp -r $(base_dir)/scss/* $(working_dir)/scss/
+	cp -r $(base_dir)/headers/* $(working_dir)/headers/
+endef
 
 # $(1) is the name of operating system, $(2) is typora or pandoc, $(3) is light or dark theme
 define build
@@ -27,6 +37,7 @@ endef
 
 # $(1) is the name of operating system
 define build-typora
+	$(call update-build)
 	$(call build,$(1),$(typora),light)
 	$(call build,$(1),$(typora),dark)
 	if [ "$(1)" = "$(windows)" ]; then \
@@ -41,6 +52,7 @@ define build-typora
 endef
 
 define build-pandoc
+	$(call update-build)
 	$(call build,$(linux),$(pandoc),light)
 	$(call build,$(linux),$(pandoc),dark)
 endef

--- a/src/scss/blockquote.scss
+++ b/src/scss/blockquote.scss
@@ -1,31 +1,26 @@
 $os: "" !default;
 $theme: "" !default;
 
-/* 一个>的引言仅为两字符缩进，使用>>的引言为传统引言样式，具有左竖线、左缩进 */
+//把变量都变成可以动态调整的，并解决了边框间距以及字的大小变化问题
 
 blockquote {
   font-style: normal;
   font-family: var(--quote-latin-font), var(--quote-chinese-font), var(--base-latin-font), var(--base-chinese-font), -apple-system, serif;
   font-size: var(--quote-font-size);
-  /* 文字离左边框的距离 */
-  padding-left: 2em;
-  padding-right: 2em;
-  /* 左边框离页面边的距离 */
+  
+  border-left: calc(var(--blockquote-border-enabled) * var(--blockquote-border-width)) solid var(--blockquote-border-color);
+  padding-left: calc(var(--blockquote-padding-left) - (var(--blockquote-border-enabled) * var(--blockquote-border-width)));
+  padding-right: var(--blockquote-padding-right);
   margin-left: 0;
 }
 
-// blockquote p:first-child {
-//   padding-top: 1ch;
-// }
-
-// blockquote p:last-child {
-//   padding-bottom: 1ch;
-// }
-
 blockquote blockquote {
-  border-left: 4px solid hsl(0, 0%, 70%);
-  padding-left: calc(2ch - 4px);
+  //修改，持嵌套引用与父级相同字体大小，防止间距和字体变大
+  font-size: 1em;
+  border-left: calc(var(--blockquote-border-enabled) * var(--blockquote-border-width)) solid var(--blockquote-border-color);
+  padding-left: calc(var(--blockquote-padding-left) - (var(--blockquote-border-enabled) * var(--blockquote-border-width)));
+  // 嵌套引用不需要右侧缩进
   padding-right: 0;
-  margin-left: -4px;
+  margin-left: calc(var(--blockquote-border-enabled) * -1 * var(--blockquote-border-width));
   border-radius: 0;
 }

--- a/src/scss/blockquote.scss
+++ b/src/scss/blockquote.scss
@@ -1,25 +1,25 @@
 $os: "" !default;
 $theme: "" !default;
 
-//把变量都变成可以动态调整的，并解决了边框间距以及字的大小变化问题
-
 blockquote {
   font-style: normal;
   font-family: var(--quote-latin-font), var(--quote-chinese-font), var(--base-latin-font), var(--base-chinese-font), -apple-system, serif;
   font-size: var(--quote-font-size);
-  
+  /* 左侧引用框  */
   border-left: calc(var(--blockquote-border-enabled) * 4px) solid var(--blockquote-border-color);
+  /* 文字离左边框的距离 */
   padding-left: calc(2em - (var(--blockquote-border-enabled) * 4px));
   padding-right: 2em;
+  /* 左边框离页面边的距离 */
   margin-left: 0;
 }
 
 blockquote blockquote {
-  //修改，持嵌套引用与父级相同字体大小，防止间距和字体变大
+  /* 持嵌套引用与父级相同字体大小，防止间距和字体变大 */
   font-size: 1em;
   border-left: calc(var(--blockquote-border-enabled) * 4px) solid var(--blockquote-border-color);
   padding-left: calc(2em - (var(--blockquote-border-enabled) * 4px));
-  // 嵌套引用不需要右侧缩进
+  /* 嵌套引用不需要右侧缩进 */
   padding-right: 0;
   margin-left: calc(var(--blockquote-border-enabled) * -1 * 4px);
   border-radius: 0;

--- a/src/scss/blockquote.scss
+++ b/src/scss/blockquote.scss
@@ -5,7 +5,7 @@ blockquote {
   font-style: normal;
   font-family: var(--quote-latin-font), var(--quote-chinese-font), var(--base-latin-font), var(--base-chinese-font), -apple-system, serif;
   font-size: var(--quote-font-size);
-  /* 左侧引用框  */
+  /* 左侧边框  */
   border-left: calc(var(--blockquote-border-enabled) * 4px) solid var(--blockquote-border-color);
   /* 文字离左边框的距离 */
   padding-left: calc(2em - (var(--blockquote-border-enabled) * 4px));
@@ -15,12 +15,6 @@ blockquote {
 }
 
 blockquote blockquote {
-  /* 持嵌套引用与父级相同字体大小，防止间距和字体变大 */
-  font-size: 1em;
-  border-left: calc(var(--blockquote-border-enabled) * 4px) solid var(--blockquote-border-color);
-  padding-left: calc(2em - (var(--blockquote-border-enabled) * 4px));
-  /* 嵌套引用不需要右侧缩进 */
+  font-size: inherit;
   padding-right: 0;
-  margin-left: calc(var(--blockquote-border-enabled) * -1 * 4px);
-  border-radius: 0;
 }

--- a/src/scss/blockquote.scss
+++ b/src/scss/blockquote.scss
@@ -8,19 +8,19 @@ blockquote {
   font-family: var(--quote-latin-font), var(--quote-chinese-font), var(--base-latin-font), var(--base-chinese-font), -apple-system, serif;
   font-size: var(--quote-font-size);
   
-  border-left: calc(var(--blockquote-border-enabled) * var(--blockquote-border-width)) solid var(--blockquote-border-color);
-  padding-left: calc(var(--blockquote-padding-left) - (var(--blockquote-border-enabled) * var(--blockquote-border-width)));
-  padding-right: var(--blockquote-padding-right);
+  border-left: calc(var(--blockquote-border-enabled) * 4px) solid var(--blockquote-border-color);
+  padding-left: calc(2em - (var(--blockquote-border-enabled) * 4px));
+  padding-right: 2em;
   margin-left: 0;
 }
 
 blockquote blockquote {
   //修改，持嵌套引用与父级相同字体大小，防止间距和字体变大
   font-size: 1em;
-  border-left: calc(var(--blockquote-border-enabled) * var(--blockquote-border-width)) solid var(--blockquote-border-color);
-  padding-left: calc(var(--blockquote-padding-left) - (var(--blockquote-border-enabled) * var(--blockquote-border-width)));
+  border-left: calc(var(--blockquote-border-enabled) * 4px) solid var(--blockquote-border-color);
+  padding-left: calc(2em - (var(--blockquote-border-enabled) * 4px));
   // 嵌套引用不需要右侧缩进
   padding-right: 0;
-  margin-left: calc(var(--blockquote-border-enabled) * -1 * var(--blockquote-border-width));
+  margin-left: calc(var(--blockquote-border-enabled) * -1 * 4px);
   border-radius: 0;
 }

--- a/src/scss/settings.scss
+++ b/src/scss/settings.scss
@@ -32,10 +32,7 @@ $theme: "" !default;
   /* == 引用块设置 == */
   /* 1 表示启用边框，0 表示禁用 */
   --blockquote-border-enabled: 1; /* 1 表示启用边框，0 表示禁用 */
-  --blockquote-border-width: 4px; /* 边框粗细 */
   --blockquote-border-color: hsl(0, 0%, 70%); /* 边框颜色 */
-  --blockquote-padding-left: 2em; /* 左侧缩进 */
-  --blockquote-padding-right: 2em; /* 右侧缩进 */
 
   /* == 字体设置 == */
 

--- a/src/scss/settings.scss
+++ b/src/scss/settings.scss
@@ -28,6 +28,14 @@ $theme: "" !default;
     $chinese-kai-font: "Noto Serif CJK SC";  // FIXME: 找到合适的开源楷体
     $chinese-fangsong-font: "Noto Serif CJK SC";  // FIXME: 找到合适的开源仿宋字体
   }
+  
+  /* == 引用块设置 == */
+  /* 1 表示启用边框，0 表示禁用 */
+  --blockquote-border-enabled: 1; /* 1 表示启用边框，0 表示禁用 */
+  --blockquote-border-width: 4px; /* 边框粗细 */
+  --blockquote-border-color: hsl(0, 0%, 70%); /* 边框颜色 */
+  --blockquote-padding-left: 2em; /* 左侧缩进 */
+  --blockquote-padding-right: 2em; /* 右侧缩进 */
 
   /* == 字体设置 == */
 


### PR DESCRIPTION
## 修复 (fix)：
- 解决了blockquote边框启用/禁用时的对齐问题
- 确保所有嵌套引用块保持一致的缩进和对齐
- ~~改进了Makefile构建流程，添加了`update-build`函数，确保每次构建都使用最新的源文件副本。~~ 后续进展见 #186

## 新功能 (feat)：
- 添加了CSS变量作为"功能开关"，一键控制所有blockquote边框的显示
- 增加了边框宽度、颜色和左右缩进距离的自定义选项，用户可以通过在typora中：文件 -> 偏好设置-> 外观-> 主题文件夹-> 找到latex.css/latex-dark.css->更改“/* == 引用块设置 == */”部分并重启typora进行自定义引用块



## 实现方式

1. 在`settings.scss`中添加以下CSS变量：
   - `--blockquote-border-enabled`：边框开关（1=显示，0=隐藏）
   - ~~`--blockquote-border-width`：边框宽度~~
   - `--blockquote-border-color`：边框颜色
   - ~~`--blockquote-padding-left`/`--blockquote-padding-right`：左右缩进~~

2. 修改`blockquote.scss`使用这些变量，并通过`calc()`函数动态调整padding，确保无论边框是否启用，内容都保持对齐


Fixes #177 
