### PR TITLE
fix: resolve third-level list spacing compression in PDF export

### DIFF
--- a/src/scss/list.scss
+++ b/src/scss/list.scss
@@ -38,11 +38,6 @@ $theme: "" !default;
         counter-increment: liiist;
         position: relative;
       }
-      > li + li {
-        @media print {
-          margin-bottom: 1em;
-        }
-      }
       > li::before {
         content: counter(liiist, lower-roman) ".";
         align-self: flex-end;
@@ -62,34 +57,21 @@ $theme: "" !default;
 #write ol, 
 #write ul {
   padding-inline-start: 2em;
+  // NOTE: 由于老版本 Typora 的 bug，第三级列表在渲染为 HTML 时丢失 p 标签，只能预先把所有 列表 的上下边距清零。
+  margin-block: 0;
 }
 
 #write {
   li {
     position: relative;
+    margin-block: 0.2em;
   }
-  li+li {
-    @media print {
-      margin-bottom: 1em;
-    }
-  }
-  
-  // 混合列表的间距调整，使用更简单的选择器以兼容低版本浏览器内核
-  ul+ol li:first-child,
-  ol+ul li:first-child {
-    @media print {
-      margin-bottom: 1em;
-    }
-  }
-  
-  // 嵌套列表的间距调整，分解复杂选择器
-  li ul li:first-child,
-  li ol li:first-child {
-    @media print {
-      margin-bottom: 1em;
-    }
+  li > p {
+    // NOTE: 由于老版本 Typora 的 bug，第三级列表在渲染为 HTML 时丢失 p 标签，只能预先把所有 li > p 的上下边距清零。
+    margin-block: 0;
   }
 }
+
 /* task列表 */
 .md-task-list-item>input{
   margin-top: 0.42em;


### PR DESCRIPTION
## 修复第三级列表 PDF 导出间距异常

### 问题描述
第三级有序/无序列表在 PDF 导出时行间距被过度压缩，导致可读性下降（见 #131 & #191 ）

### 根本原因
1. 第三级列表有 `margin: 0;` 规则，移除了容器默认边距
2. 缺少针对 PDF 导出环境的间距控制

### 解决方案
1. 移除第三级列表的 `margin: 0;`，恢复正常容器间距
2. 为所有列表层级添加 `@media print` 规则，统一使用 `0.42em` 间距（这个数值我参考 task, 与 task 列表一致）
3. 屏幕显示保持浏览器默认样式，无需额外干预

### 测试(中文&英文测试)
1. 错误版本
	- 中文
		<img width="286" height="570" alt="image" src="https://github.com/user-attachments/assets/fe4f389e-7d82-4539-868a-7c668b8bafea" />
	- 英文
		<img width="217" height="558" alt="image" src="https://github.com/user-attachments/assets/ec141cb7-916a-4c42-a6c3-bb767f833b69" />

2 .  修改后版本
	- 中文版本
		<img width="247" height="663" alt="image" src="https://github.com/user-attachments/assets/77c40b74-2eef-41b3-bd16-2e1051de30af" />
	- 英文版本
		<img width="208" height="618" alt="image" src="https://github.com/user-attachments/assets/e9b9f110-e3e0-4090-9bb2-dcc9ddf922cc" />

3. 如果感觉间距大(修改@media print里面的top值就好, 下面为例子,  我就用中文为例缩小一些)
<img width="305" height="533" alt="image" src="https://github.com/user-attachments/assets/458f3ff6-4b36-488d-9424-e3b5750eafbd" />



Fixes issue #131
want merge in pr #191  