### PR TITLE
fix: use English font name for macOS 26

### DIFF
--- a/src/scss/settings.scss
+++ b/src/scss/settings.scss
@@ -16,11 +16,11 @@ $theme: "" !default;
     $chinese-kai-font: "华文楷体";
     $chinese-fangsong-font: "华文仿宋";
   } @else if $os == "macos" {
-    $ui-font: "苹方-简";
-    $chinese-sans-serif-font: "华文黑体Bold", "方正公文黑体";
-    $chinese-serif-font: "家族宋", "宋体-简";
-    $chinese-kai-font: "方正公文楷体";
-    $chinese-fangsong-font: "方正公文仿宋";
+    $ui-font: "PingFang SC";
+    $chinese-sans-serif-font: "STHeitiBold", "FZDocHei";
+    $chinese-serif-font: "Family Song", "Songti SC";
+    $chinese-kai-font: "FZDocKai";
+    $chinese-fangsong-font: "FZDocFangSong";
   } @else if $os == "linux" {
     $ui-font: "Noto Sans CJK SC";
     $chinese-sans-serif-font: "Noto Sans CJK SC";
@@ -44,7 +44,7 @@ $theme: "" !default;
 
   /* 引言字体 */
   --quote-latin-font: "Latin Modern Roman", "Latin Modern Roman 10", Times, "Times New Roman";
-  --quote-chinese-font: "华文仿宋";
+  --quote-chinese-font: "华文仿宋", "STFangsong";
   /* em单位为一个正文字符（--base-font-size）大小，
   例如，如果您设置 --base-font-size 为 9.5pt，那么 1.05em = 1.05*9.5pt ≈ 10pt。下面的标题字体等设置也遵循该规则。
   这样，您就可以仅通过调整基准字体大小，而动态对其他元素大小做出调整。


### PR DESCRIPTION
In macOS 26, using Chinese font family names to set fonts seems to be unrecognized by the system; use English font names instead.

Tested on my mac.