### PR TITLE
fix: update print page margin

### DIFF
--- a/src/scss/settings.scss
+++ b/src/scss/settings.scss
@@ -28,7 +28,7 @@ $theme: "" !default;
     $chinese-kai-font: "Noto Serif CJK SC";  // FIXME: 找到合适的开源楷体
     $chinese-fangsong-font: "Noto Serif CJK SC";  // FIXME: 找到合适的开源仿宋字体
   }
-  
+
   /* == 引用块设置 == */
   /* 1 表示启用边框，0 表示禁用 */
   --blockquote-border-enabled: 1; /* 1 表示启用边框，0 表示禁用 */
@@ -121,7 +121,7 @@ $theme: "" !default;
 
   /* == 页面设置 == */
   /* 打印页边距 */
-  --set-margin: 1.8cm 2cm 1.2cm 2cm !important;
+  --set-margin: 1.8cm 2cm 1.6cm 2cm;
 
   /* == 控制设置 == */
   /* 目录中是否显示一级标题 */

--- a/src/scss/text.scss
+++ b/src/scss/text.scss
@@ -23,7 +23,7 @@ body {
     break-before: avoid-page;
   }
   @page {
-    margin: 1.8cm 2cm 1.2cm 2cm !important; /* 页边距 */
+    margin: var(--set-margin) !important;
   }
 }
 
@@ -39,7 +39,7 @@ body {
   }
   /* column-count: 2;
     column-gap: 25px;
-    column-width: 8cm; 
+    column-width: 8cm;
     display: inline-block; */
   /* 这里可以试分栏的，但确实不适合实现 */
 


### PR DESCRIPTION
- 打印页边距使用已有的 `--set-margin` CSS 变量
- 提高默认下边距到 1.6cm

---

起因是遇到了内容在页面底部被裁切的问题。与此前 issue 中提到的分页问题不同，这个裁切并不是把内容切开分在两页上，而是这部分内容的下半部分直接「消失」了。使用 Acrobat 编辑发现，在页面底部有一个与背景色相同的矩形框，将内容挡住了：

<img width="1690" height="1168" alt="image" src="https://github.com/user-attachments/assets/7348df98-800e-4acb-9ea4-05f179037cd9" />


将这个框移走就可以看到下方的内容：

<img width="1690" height="1168" alt="image" src="https://github.com/user-attachments/assets/759d2566-d469-4cc5-9278-26574ac2fb63" />


检查 Typora 源码发现在 `frame.js` 中有一段：

```js
await JSBridge.invoke("export.printToPDF", s, {
  taskLabel: "content",
  printBackground: !0,
  margins: {
    left: 0,
    right: 0,
    top:
      ("custom" === a["paper.margin"] ? C(a["paper.marginTop"], 16) : 16) * l,
    bottom:
      ("custom" === a["paper.margin"] ? C(a["paper.marginBottom"], 16) : 16) *
      l,
  },
  pageSize: i,
});
```

`printBackground` 选项硬编码为真。这明显对应 Electron 中 `webContents.print` 方法。这个选项会取页面背景色，然后在页边距之外的上下部分补上两个矩形框来把页面背景补完整。就是这个矩形框遮挡了内容。而打印边距默认设置为了 16，单位应该是毫米。测量 PDF 上的矩形高度，大致吻合。因此将下边距提高到 1.6cm。