### PR TITLE
fix: update github action version

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -5,14 +5,14 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  DART_SASS_VERSION: 1.81.0
+  DART_SASS_VERSION: 1.99.0
 
 jobs:
   compile:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Dart Sass
         uses: robinraju/release-downloader@v1
         with:
@@ -29,7 +29,7 @@ jobs:
           cd ./src
           make -j3
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: my-artifact
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,14 @@ on:
       - v*
 
 env:
-  DART_SASS_VERSION: 1.81.0
+  DART_SASS_VERSION: 1.99.0
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Dart Sass
         uses: robinraju/release-downloader@v1
         with:
@@ -30,7 +30,7 @@ jobs:
           cd ./src
           make all-and-compress -j3
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: ./src/latex-theme/*.zip


### PR DESCRIPTION
Some github actions are deprecated. Update to the latest version.
Update `DART_SASS_VERSION` to the latest version.